### PR TITLE
some frontend and changed to HTTPS with jwt tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ coverage.xml
 .tox/
 .nox/
 .pytest_cache/
+
+# Local SSL certificates
+*.pem

--- a/backend/reptrack_backend/settings.py
+++ b/backend/reptrack_backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 
 from pathlib import Path
 from decouple import config
+from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -38,8 +39,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'rest_framework.authtoken',
+    'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
+    # 'rest_framework.authtoken',
     'corsheaders',
+    'sslserver',
+    'django_extensions',
     'users',
     'workouts',
 ]
@@ -135,12 +140,13 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",  # Vite dev server default
     "http://127.0.0.1:5173"
 ]
+CORS_ALLOW_CREDENTIALS = True
 
 AUTH_USER_MODEL = 'users.User'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.TokenAuthentication',
+        'users.authentication.JWTAuthenticationFromCookie',
     ],
     'DEFAULT_THROTTLE_CLASSES': [
         'rest_framework.throttling.AnonRateThrottle',
@@ -153,9 +159,17 @@ REST_FRAMEWORK = {
     }
 }
 
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=15),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'ROTATE_REFRESH_TOKENS': True,
+    'BLACKLIST_AFTER_ROTATION': True,
+    'AUTH_HEADER_TYPES': ('Bearer',),
+}
+
 AUTHENTICATION_BACKENDS = [
     'users.backends.CaseInsensitiveEmailBackend',
     'django.contrib.auth.backends.ModelBackend',
 ]
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' # change for production

--- a/backend/users/authentication.py
+++ b/backend/users/authentication.py
@@ -1,0 +1,9 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+class JWTAuthenticationFromCookie(JWTAuthentication):
+    def authenticate(self, request):
+        raw_token = request.COOKIES.get('access_token')
+        if not raw_token:
+            return None
+        validated_token = self.get_validated_token(raw_token)
+        return self.get_user(validated_token), validated_token

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 from rest_framework.authtoken.views import obtain_auth_token
-from .views import RegisterView, VerifyEmailView, LoginView, LogoutView, PasswordResetRequestView, PasswordResetConfirmView, ChangePasswordView, UserProfileView, ResendVerificationEmailView
+from .views import RegisterView, VerifyEmailView, LogoutView, PasswordResetRequestView, PasswordResetConfirmView, ChangePasswordView, UserProfileView, ResendVerificationEmailView, MyTokenObtainPairView, CookieTokenRefreshView
 
 urlpatterns = [
     path('register/', RegisterView.as_view(), name='register'),
     path('verify-email/<uidb64>/<token>/', VerifyEmailView.as_view(), name='verify-email'),
-    path('login/', LoginView.as_view(), name='login'),
+    path('login/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', CookieTokenRefreshView.as_view(), name='token_refresh'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('password-reset/', PasswordResetRequestView.as_view(), name='password-reset-request'),
     path('password-reset-confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password-reset-confirm'),

--- a/frontend/.vite/deps/_metadata.json
+++ b/frontend/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "4f442f5a",
+  "configHash": "dba2d5ea",
+  "lockfileHash": "6ba273fb",
+  "browserHash": "612a556b",
+  "optimized": {},
+  "chunks": {}
+}

--- a/frontend/.vite/deps/package.json
+++ b/frontend/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <!-- <link rel="icon" type="image/svg+xml" href="/vite.svg" /> -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RepTrack</title>
   </head>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,9 @@ import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import Landing from "./pages/Landing";
+import Dashboard from "./pages/Dashboard";
+import Profile from "./pages/Profile";
 
 function App() {
   const [count, setCount] = useState(0);
@@ -11,8 +14,11 @@ function App() {
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Login />} />
+          <Route path="/" element={<Landing />} />
+          <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/profile" element={<Profile />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router-dom";
+
+export default function DashboardPage() {
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    try {
+      const response = await fetch("https://127.0.0.1:8000/api/v1/users/logout/", {
+        method: "POST",
+        credentials: "include", // Send cookies
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (response.ok) {
+        navigate("/"); // Go back to landing page
+      } else {
+        console.error("Logout failed");
+      }
+    } catch (error) {
+      console.error("Error during logout:", error);
+    }
+  };
+
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-3xl mb-4">DASHBOARD</h1>
+      <button
+        onClick={handleLogout}
+        className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700"
+      >
+        Logout
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,0 +1,16 @@
+export default function LandingPage() {
+  return (
+    <div className="p-10 text-center">
+      <h1 className="text-4xl font-bold mb-4">Welcome to RepTrack</h1>
+      <p className="text-lg text-gray-600 mb-6">
+        Track your workouts, monitor progress, and stay consistent.
+      </p>
+      <a
+        href="/login"
+        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition"
+      >
+        Log In
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,26 +1,28 @@
 import { useState } from "react";
 import axios from "axios";
 import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError("");
 
     try {
-      const response = await axios.post("http://127.0.0.1:8000/api/v1/users/login/", {
-        email,
-        password,
-      });
+      const response = await axios.post(
+        "https://127.0.0.1:8000/api/v1/users/login/",
+        {email, password},
+        {withCredentials: true}
+      );
 
-      console.log("Login successful:", response.data);
+      // console.log("Login successful:", response.data);
 
-      localStorage.setItem("access", response.data.access);
-      localStorage.setItem("refresh", response.data.refresh);
+      navigate("/dashboard");
     } catch (err) {
       console.error("Login failed:", err.response?.data || err.message);
       setError("Login failed. Check your email and password.");
@@ -52,14 +54,27 @@ export default function Login() {
             style={{ width: "100%", padding: "0.5rem" }}
           />
         </div>
-        <button type="submit" style={{ padding: "0.5rem 1rem", marginBottom: "1rem" }}>
+        <button
+          type="submit"
+          style={{ padding: "0.5rem 1rem", marginBottom: "1rem" }}
+        >
           Log In
         </button>
 
-        <p style={{ marginBottom: "0.5rem", textAlign: "center", cursor: "pointer", color: "blue" }}>
+        <p
+          style={{
+            marginBottom: "0.5rem",
+            textAlign: "center",
+            cursor: "pointer",
+            color: "blue",
+          }}
+        >
           Forgot Password?
         </p>
-        <Link to="/register" style={{ textAlign: "center", cursor: "pointer", color: "blue" }}>
+        <Link
+          to="/register"
+          style={{ textAlign: "center", cursor: "pointer", color: "blue" }}
+        >
           Create Account
         </Link>
       </form>

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    axios.get("https://127.0.0.1:8000/api/v1/users/profile/", {
+      withCredentials: true
+    })
+    .then(res => {
+      setProfile(res.data);
+    })
+    .catch(err => {
+      console.error("Profile fetch failed:", err);
+      setError("Failed to load profile. Are you logged in?");
+    });
+  }, []);
+
+  if (error) return <p className="text-red-500">{error}</p>;
+  if (!profile) return <p>Loading profile...</p>;
+
+  return (
+    <div className="p-4 rounded bg-gray-100 shadow">
+      <h2 className="text-xl font-bold mb-2">User Profile</h2>
+      <p><strong>Username:</strong> {profile.username}</p>
+      <p><strong>Email:</strong> {profile.email}</p>
+      {/* Add more fields if your serializer includes them */}
+    </div>
+  );
+}

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -22,7 +22,7 @@ export default function Register() {
 
     try {
       const response = await axios.post(
-        "http://localhost:8000/api/v1/users/register/",
+        "https://localhost:8000/api/v1/users/register/",
         {
           email,
           password,


### PR DESCRIPTION
Implement JWT authentication with HttpOnly cookies and HTTPS setup

- Replace token-in-JSON auth with HttpOnly cookie-based JWT tokens
- Add custom JWTAuthentication to read access token from cookie
- Update login, refresh, and logout views to set/delete cookies properly
- Configure CORS and cookie settings for cross-site requests
- Set up HTTPS in dev using mkcert and Django runserver_plus
- Adjust frontend Axios calls to use credentials and HTTPS
- Add protected user profile endpoint and frontend profile component
